### PR TITLE
fixes config nesting

### DIFF
--- a/data/db-config.js
+++ b/data/db-config.js
@@ -1,5 +1,4 @@
 const knex = require('knex')
 const environment = process.env.DB_ENV || 'development'
 const config = require('../knexfile')
-
 module.exports = knex(config[environment])

--- a/knexfile.js
+++ b/knexfile.js
@@ -2,6 +2,26 @@
 require('dotenv').config()
 
 module.exports = {
+  production: {
+    client: 'pg',
+    connection: process.env.DATABASE_URL,
+    migrations: {
+      directory: './data/migrations',
+    },
+    seeds: {
+      directory: './data/seeds',
+    },
+  },
+  staging: {
+    client: 'pg',
+    connection: process.env.DATABASE_URL,
+    migrations: {
+      directory: './data/migrations',
+    },
+    seeds: {
+      directory: './data/seeds',
+    },
+  },
   development: {
     client: 'pg',
     connection: {
@@ -10,28 +30,11 @@ module.exports = {
       password: process.env.DB_PASS,
       database: process.env.DB,
     },
-
     migrations: {
       directory: './data/migrations',
     },
     seeds: {
       directory: './data/seeds',
-    },
-
-    staging: {
-      client: 'pg',
-      connection: process.env.DATABASE_URL,
-      migrations: {
-        directory: './data/migrations',
-      },
-    },
-
-    production: {
-      client: 'pg',
-      connection: process.env.DATABASE_URL,
-      migrations: {
-        directory: './data/migrations',
-      },
     },
   },
 }


### PR DESCRIPTION
# Description

- There was a deployment bug w/ the way that the knex.config file was set up. This fix takes the 'production' object in that file, and un-nests it from w/in the "development' object. Heroku couldn't read the `.config` file as a result of the nesting.

Fixes # (issue)
I would ensure that you clean up the `migrations` and `seeds` files in that config object file. 

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)
I tested this by deploying the branch manually in Heroku and the process stood up. Further clean up of that file that I fixed is recommended. 

## Change Status

- [ x] Complete, tested, ready to review and merge